### PR TITLE
ID issue when loading Submissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image from https://hub.docker.com (syntax: repo/image:version)
-FROM continuumio/miniconda3:4.5.4
+FROM continuumio/miniconda3:latest
 
 # Person responsible
 MAINTAINER helge.dzierzon@brockmann-consult.de

--- a/eocdb/db/mongo_db_driver.py
+++ b/eocdb/db/mongo_db_driver.py
@@ -133,7 +133,7 @@ class MongoDbDriver(DbDriver):
 
         submission_dict = submission.to_dict()
         if "id" in submission_dict:
-            del submission_dict["id"]
+            submission_dict["id"] = None
 
         result = self._submit_collection.replace_one({"_id": obj_id}, submission_dict)
         return result.modified_count == 1

--- a/eocdb/ws/handlers/_handlers.py
+++ b/eocdb/ws/handlers/_handlers.py
@@ -125,10 +125,8 @@ class StoreUploadUser(WsRequestHandler):
 # noinspection PyAbstractClass
 class StoreUploadSubmissionFile(WsRequestHandler):
 
-    def get(self):
-        submission_id = self.query.get_param("submission_id", default=None)
-        index_str = self.query.get_param("index", default=None)
-        index = int(index_str)
+    def get(self, submission_id: str, index: str):
+        index = int(index)
 
         submission_file = get_submission_file(ctx=self.ws_context, submission_id=submission_id, index=index)
         if submission_file is not None:
@@ -137,17 +135,15 @@ class StoreUploadSubmissionFile(WsRequestHandler):
         else:
             self.set_status(400, reason="No result found")
 
-    def delete(self):
-        submission_id = self.query.get_param("submission_id", default=None)
-        index_str = self.query.get_param("index", default=None)
-        index = int(index_str)
+    def delete(self, submission_id: str, index: str):
+        index = int(index)
 
         submission = get_submission(ctx=self.ws_context, submission_id=submission_id)
         if submission is None:
-            self.set_status(404, reason="No result found")
+            self.set_status(404, reason="Submission not found")
             return
 
-        if index >= len(submission.files):
+        if index >= len(submission.files) or index < 0:
             self.set_status(400, reason="Invalid submission file index")
             return
 

--- a/eocdb/ws/handlers/_mappings.py
+++ b/eocdb/ws/handlers/_mappings.py
@@ -31,7 +31,7 @@ MAPPINGS = [
     (url_pattern(API_URL_PREFIX + '/store/info'), StoreInfo),
     (url_pattern(API_URL_PREFIX + '/store/upload'), StoreUpload),
     (url_pattern(API_URL_PREFIX + '/store/upload/user/{userid}'), StoreUploadUser),
-    (url_pattern(API_URL_PREFIX + '/store/upload/submissionfile'), StoreUploadSubmissionFile),
+    (url_pattern(API_URL_PREFIX + '/store/upload/submissionfile/{submission_id}/{index}'), StoreUploadSubmissionFile),
     (url_pattern(API_URL_PREFIX + '/store/download'), StoreDownload),
     (url_pattern(API_URL_PREFIX + '/datasets/validate'), DatasetsValidate),
     (url_pattern(API_URL_PREFIX + '/datasets'), Datasets),

--- a/eocdb/ws/webservice.py
+++ b/eocdb/ws/webservice.py
@@ -222,7 +222,7 @@ class WsRequestHandler(RequestHandler):
         self.set_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
         self.set_header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
 
-    def options(self):
+    def options(self, *args, **kwargs):
         self.set_status(204)
         self.finish()
 

--- a/tests/ws/handlers/test_handlers.py
+++ b/tests/ws/handlers/test_handlers.py
@@ -116,8 +116,7 @@ class StoreUploadTest(WsTestCase):
 class StoreUploadSubmissionFileTest(WsTestCase):
 
     def test_get_no_results(self):
-        parameter = "submission_id=ABCDEFGHI&index=0"
-        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile?{parameter}", method='GET')
+        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile/ABCDEFGHI/0", method='GET')
 
         self.assertEqual(400, response.code)
         self.assertEqual('No result found', response.reason)
@@ -142,8 +141,7 @@ class StoreUploadSubmissionFileTest(WsTestCase):
         self.ctx.db_driver.add_submission(db_subm)
 
         # --- get submission file ---
-        parameter = "submission_id=submitme&index=0"
-        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile?{parameter}", method='GET')
+        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile/submitme/0", method='GET')
 
         self.assertEqual(200, response.code)
         self.assertEqual('OK', response.reason)
@@ -157,11 +155,10 @@ class StoreUploadSubmissionFileTest(WsTestCase):
                           'submission_id': 'submitme'}, actual_response_data)
 
     def test_delete_no_submissions(self):
-        parameter = "submission_id=ABCDEFGHI&index=0"
-        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile?{parameter}", method='DELETE')
+        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile/ABCDEFGHI/0", method='DELETE')
 
         self.assertEqual(404, response.code)
-        self.assertEqual('No result found', response.reason)
+        self.assertEqual('Submission not found', response.reason)
 
     def test_delete(self):
         files = [SubmissionFile(submission_id="submitme",
@@ -181,10 +178,10 @@ class StoreUploadSubmissionFileTest(WsTestCase):
                                path="/root/hell/yeah", date=datetime.datetime(2001, 2, 3, 4, 5, 6))
         self.ctx.db_driver.add_submission(db_subm)
 
-        parameter = "submission_id=submitme&index=0"
-        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile?{parameter}", method='DELETE')
+        response = self.fetch(API_URL_PREFIX + f"/store/upload/submissionfile/submitme/0", method='DELETE')
         self.assertEqual(200, response.code)
         self.assertEqual('OK', response.reason)
+
 
 class StoreUploadUserTest(WsTestCase):
 


### PR DESCRIPTION

- Fixed id issue when loading Submissions (id needs to be none not deleted)
- Changed mapping for submissionfiles from query string to path for submission_id and index
- Fixed tests accordingly
- Fixed options issue (CORS error). Added kwargs to options method
- Changed minoconda version in Dockerfile to latest