### PR TITLE
Get non existing Submission File not working properly

### DIFF
--- a/eocdb/ws/controllers/store.py
+++ b/eocdb/ws/controllers/store.py
@@ -367,6 +367,9 @@ def download_submission_file_by_id(ctx: WsContext,
                                    index: int = None) -> zipfile.ZipFile:
     submission = get_submission(ctx, submission_id)
 
+    if not submission:
+        return None
+
     submission_file = get_submission_file(ctx, submission_id, index)
 
     if submission_file.filetype == TYPE_MEASUREMENT:

--- a/eocdb/ws/handlers/_handlers.py
+++ b/eocdb/ws/handlers/_handlers.py
@@ -160,6 +160,10 @@ class StoreDownloadsubmissionFile(WsRequestHandler):
 
         result = download_submission_file_by_id(self.ws_context, submission_id=submission_id, index=index)
 
+        if not result:
+            self.set_status(400, reason="Submission File not found")
+
+
         self._return_zip_file(result)
         self.finish()
 

--- a/eocdb/ws/handlers/_mappings.py
+++ b/eocdb/ws/handlers/_mappings.py
@@ -52,6 +52,6 @@ MAPPINGS = [
     (url_pattern(API_URL_PREFIX + '/users'), Users),
     (url_pattern(API_URL_PREFIX + '/users/login'), UsersLogin),
     (url_pattern(API_URL_PREFIX + '/users/logout'), UsersLogout),
-    (url_pattern(API_URL_PREFIX + '/users/{id}'), UsersId),
+    (url_pattern(API_URL_PREFIX + '/users/{user_name}'), UsersId),
     (url_pattern(API_URL_PREFIX + '/links'), Links),
 ]

--- a/tests/ws/handlers/test_handlers.py
+++ b/tests/ws/handlers/test_handlers.py
@@ -698,14 +698,10 @@ class StoreDownloadTest(WsTestCase):
 
 
 class StoreDownloadsubmissionFileTest(WsTestCase):
-    def test_get(self):
+    def test_get_not_exists(self):
         response = self.fetch(API_URL_PREFIX + f"/store/download/submissionfile/sd/0", method='GET')
-        #self.assertEqual(400, response.code)
-        #self.assertEqual('OK', response.reason)
-
-        #expected_response_data = None
-        #actual_response_data = response.body
-        #self.assertEqual(expected_response_data, actual_response_data)
+        self.assertEqual(400, response.code)
+        self.assertEqual('Submission File not found', response.reason)
 
 
 


### PR DESCRIPTION
When accepting this PR atempting to get a non existing submission file will throw a 400 witgha proper message.

A test will also be added checking whether asking for non existing submission files throws a 400 error